### PR TITLE
spyderlib -> spyder

### DIFF
--- a/src/rqt_py_console/py_console.py
+++ b/src/rqt_py_console/py_console.py
@@ -36,14 +36,13 @@ from qt_gui_py_common.simple_settings_dialog import SimpleSettingsDialog
 from rqt_py_console.py_console_widget import PyConsoleWidget
 
 try:
-    from spyder_console_widget import SpyderConsoleWidget
+    from rqt_py_console.spyder_console_widget import SpyderConsoleWidget
     _has_spyderlib = True
 except ImportError:
     _has_spyderlib = False
 
 
 class PyConsole(Plugin):
-
     """
     Plugin providing an interactive Python console
     """
@@ -90,8 +89,11 @@ class PyConsole(Plugin):
     def trigger_configuration(self):
         options = [
             {'title': 'SpyderConsole',
-                'description': 'Advanced Python console with tab-completion (needs spyderlib to be installed).', 'enabled': _has_spyderlib},
-            {'title': 'PyConsole', 'description': 'Simple Python console.'},
+             'description':
+                'Advanced Python console with tab-completion (needs spyderlib to be installed).',
+             'enabled': _has_spyderlib},
+            {'title': 'PyConsole',
+             'description': 'Simple Python console.'},
         ]
         dialog = SimpleSettingsDialog(title='PyConsole Options')
         dialog.add_exclusive_option_group(

--- a/src/rqt_py_console/spyder_console_widget.py
+++ b/src/rqt_py_console/spyder_console_widget.py
@@ -32,9 +32,8 @@
 
 from python_qt_binding.QtGui import QFont
 
-from spyderlib.widgets.internalshell import InternalShell
-from spyderlib.utils.module_completion import moduleCompletion
-
+from spyder.widgets.internalshell import InternalShell
+from spyder.utils.module_completion import moduleCompletion
 
 class SpyderConsoleWidget(InternalShell):
 


### PR DESCRIPTION
spyderlib should be spyder

Note: `from spyder.utils.module_completion import moduleCompletion` always fails as moduleCompletion does not exist in the spyder project in either 2.7 or 3.x. Removing the moduleCompletion code crashes with `QWidget: Must construct a QApplication before a QPaintDevice`
 
@dirk-thomas Any ideas what this method was trying to accomplish? 
