### PR TITLE
Fix modern setuptools warning about dashes instead of underscores.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_py_console
+script_dir=$base/lib/rqt_py_console
 [install]
-install-scripts=$base/lib/rqt_py_console
+install_scripts=$base/lib/rqt_py_console


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>