### PR TITLE
Fix a crash in the rqt_py_console dialog box.

### DIFF
--- a/src/rqt_py_console/py_console.py
+++ b/src/rqt_py_console/py_console.py
@@ -99,6 +99,9 @@ class PyConsole(Plugin):
         dialog.add_exclusive_option_group(
             title='Console Type', options=options, selected_index=int(not self._use_spyderlib))
         console_type = dialog.get_settings()[0]
+        if console_type is None:
+            # The console_type can be None if the user Canceled the dialog
+            return
         new_use_spyderlib = {0: True, 1: False}.get(
             console_type['selected_index'], self._use_spyderlib)
         if self._use_spyderlib != new_use_spyderlib:


### PR DESCRIPTION
This commit fixes an issue when you click on the "gear" icon in the rqt_py_console.  That pops up a dialog box, but if you click "Cancel" there it currently crashes. That's because clicking Cancel returns None, but then we subsequently try to subscript it.  If we get a None out of the dialog, just skip any further processing.