### PR TITLE
fix setuptools deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     license='BSD',
     extras_require={
         'test': [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -31,7 +30,11 @@ setup(
         'rqt_py_console is a Python GUI plugin providing an interactive Python console.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest'
+        ]
+    },
     entry_points={
         'console_scripts': [
             'rqt_py_console = ' + package_name + '.main:main',


### PR DESCRIPTION
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: BSD License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************